### PR TITLE
Set Product Bundle Identifier to name with a dot

### DIFF
--- a/AsyncNinja.xcodeproj/project.pbxproj
+++ b/AsyncNinja.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				INFOPLIST_FILE = AsyncNinja.xcodeproj/AsyncNinja_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = AsyncNinja;
+				PRODUCT_BUNDLE_IDENTIFIER = com.asyncNinja.asyncNinja;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -744,7 +744,7 @@
 				INFOPLIST_FILE = AsyncNinja.xcodeproj/AsyncNinja_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = AsyncNinja;
+				PRODUCT_BUNDLE_IDENTIFIER = com.asyncNinja.asyncNinja;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
![Screen Shot 2019-10-08 at 10 45 11 PM](https://user-images.githubusercontent.com/2803931/66429015-d3cfaf80-ea1f-11e9-9f90-872be0f5edf1.png)

To fix this, I had to set framework's Product Bundle Identifier to anything with a dot. 

For some reason Xcode would automatically append some autogenerated ID (5555494493d11a8e5f473d1cb2a5d781973d171e) when Product Bundle Identifier was just "AsyncNinja".

When I set Product Bundle Identifier to new value, Xcode stopped to auto-append anything, and everything works because ids match. Probably absence of a dot was the reason.